### PR TITLE
Remove stale PID file in FreeBSD init script

### DIFF
--- a/init.freebsd
+++ b/init.freebsd
@@ -33,4 +33,10 @@ procname="*python"
 command=${sickbeard_dir}/SickBeard.py
 command_args="--datadir=${sickbeard_dir} --daemon --pidfile=${pidfile}"
 
+pid=$(check_pidfile $pidfile $command python)
+if [ -z "$pid" ] && [ -f $pidfile ]; then
+  echo "Stale PID file found, removing."
+  rm $pidfile
+fi
+
 run_rc_command "$1"


### PR DESCRIPTION
This checks for a stale PID file in the FreeBSD init script and removes it. It is only removed when the PID does not have a valid SickBeard process associated.

If this is not present the PID file needs to be removed manually if SickBeard does not terminate correctly.
